### PR TITLE
[Mission/#2-Rochelle] 1일차 미션

### DIFF
--- a/RochelleDevLabApp/RochelleDevLabApp.xcodeproj/project.pbxproj
+++ b/RochelleDevLabApp/RochelleDevLabApp.xcodeproj/project.pbxproj
@@ -1,0 +1,612 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6D97A8512CD24D4C00164183 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D97A8502CD24D4C00164183 /* AppDelegate.swift */; };
+		6D97A8532CD24D4C00164183 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D97A8522CD24D4C00164183 /* SceneDelegate.swift */; };
+		6D97A8552CD24D4C00164183 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D97A8542CD24D4C00164183 /* ViewController.swift */; };
+		6D97A8582CD24D4C00164183 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6D97A8572CD24D4C00164183 /* Base */; };
+		6D97A85A2CD24D4D00164183 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6D97A8592CD24D4D00164183 /* Assets.xcassets */; };
+		6D97A85D2CD24D4D00164183 /* Base in Resources */ = {isa = PBXBuildFile; fileRef = 6D97A85C2CD24D4D00164183 /* Base */; };
+		6D97A8682CD24D4D00164183 /* RochelleDevLabAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D97A8672CD24D4D00164183 /* RochelleDevLabAppTests.swift */; };
+		6D97A8722CD24D4D00164183 /* RochelleDevLabAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D97A8712CD24D4D00164183 /* RochelleDevLabAppUITests.swift */; };
+		6D97A8742CD24D4D00164183 /* RochelleDevLabAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D97A8732CD24D4D00164183 /* RochelleDevLabAppUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		6D97A8642CD24D4D00164183 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6D97A8452CD24D4C00164183 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6D97A84C2CD24D4C00164183;
+			remoteInfo = RochelleDevLabApp;
+		};
+		6D97A86E2CD24D4D00164183 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6D97A8452CD24D4C00164183 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6D97A84C2CD24D4C00164183;
+			remoteInfo = RochelleDevLabApp;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		6D97A84D2CD24D4C00164183 /* RochelleDevLabApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RochelleDevLabApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D97A8502CD24D4C00164183 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6D97A8522CD24D4C00164183 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		6D97A8542CD24D4C00164183 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		6D97A8572CD24D4C00164183 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		6D97A8592CD24D4D00164183 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		6D97A85C2CD24D4D00164183 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		6D97A85E2CD24D4D00164183 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6D97A8632CD24D4D00164183 /* RochelleDevLabAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RochelleDevLabAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D97A8672CD24D4D00164183 /* RochelleDevLabAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RochelleDevLabAppTests.swift; sourceTree = "<group>"; };
+		6D97A86D2CD24D4D00164183 /* RochelleDevLabAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RochelleDevLabAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6D97A8712CD24D4D00164183 /* RochelleDevLabAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RochelleDevLabAppUITests.swift; sourceTree = "<group>"; };
+		6D97A8732CD24D4D00164183 /* RochelleDevLabAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RochelleDevLabAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6D97A84A2CD24D4C00164183 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D97A8602CD24D4D00164183 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D97A86A2CD24D4D00164183 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6D97A8442CD24D4C00164183 = {
+			isa = PBXGroup;
+			children = (
+				6D97A84F2CD24D4C00164183 /* RochelleDevLabApp */,
+				6D97A8662CD24D4D00164183 /* RochelleDevLabAppTests */,
+				6D97A8702CD24D4D00164183 /* RochelleDevLabAppUITests */,
+				6D97A84E2CD24D4C00164183 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6D97A84E2CD24D4C00164183 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6D97A84D2CD24D4C00164183 /* RochelleDevLabApp.app */,
+				6D97A8632CD24D4D00164183 /* RochelleDevLabAppTests.xctest */,
+				6D97A86D2CD24D4D00164183 /* RochelleDevLabAppUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6D97A84F2CD24D4C00164183 /* RochelleDevLabApp */ = {
+			isa = PBXGroup;
+			children = (
+				6D97A8502CD24D4C00164183 /* AppDelegate.swift */,
+				6D97A8522CD24D4C00164183 /* SceneDelegate.swift */,
+				6D97A8542CD24D4C00164183 /* ViewController.swift */,
+				6D97A8562CD24D4C00164183 /* Main.storyboard */,
+				6D97A8592CD24D4D00164183 /* Assets.xcassets */,
+				6D97A85B2CD24D4D00164183 /* LaunchScreen.storyboard */,
+				6D97A85E2CD24D4D00164183 /* Info.plist */,
+			);
+			path = RochelleDevLabApp;
+			sourceTree = "<group>";
+		};
+		6D97A8662CD24D4D00164183 /* RochelleDevLabAppTests */ = {
+			isa = PBXGroup;
+			children = (
+				6D97A8672CD24D4D00164183 /* RochelleDevLabAppTests.swift */,
+			);
+			path = RochelleDevLabAppTests;
+			sourceTree = "<group>";
+		};
+		6D97A8702CD24D4D00164183 /* RochelleDevLabAppUITests */ = {
+			isa = PBXGroup;
+			children = (
+				6D97A8712CD24D4D00164183 /* RochelleDevLabAppUITests.swift */,
+				6D97A8732CD24D4D00164183 /* RochelleDevLabAppUITestsLaunchTests.swift */,
+			);
+			path = RochelleDevLabAppUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6D97A84C2CD24D4C00164183 /* RochelleDevLabApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6D97A8772CD24D4D00164183 /* Build configuration list for PBXNativeTarget "RochelleDevLabApp" */;
+			buildPhases = (
+				6D97A8492CD24D4C00164183 /* Sources */,
+				6D97A84A2CD24D4C00164183 /* Frameworks */,
+				6D97A84B2CD24D4C00164183 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RochelleDevLabApp;
+			productName = RochelleDevLabApp;
+			productReference = 6D97A84D2CD24D4C00164183 /* RochelleDevLabApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		6D97A8622CD24D4D00164183 /* RochelleDevLabAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6D97A87A2CD24D4D00164183 /* Build configuration list for PBXNativeTarget "RochelleDevLabAppTests" */;
+			buildPhases = (
+				6D97A85F2CD24D4D00164183 /* Sources */,
+				6D97A8602CD24D4D00164183 /* Frameworks */,
+				6D97A8612CD24D4D00164183 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6D97A8652CD24D4D00164183 /* PBXTargetDependency */,
+			);
+			name = RochelleDevLabAppTests;
+			productName = RochelleDevLabAppTests;
+			productReference = 6D97A8632CD24D4D00164183 /* RochelleDevLabAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		6D97A86C2CD24D4D00164183 /* RochelleDevLabAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6D97A87D2CD24D4D00164183 /* Build configuration list for PBXNativeTarget "RochelleDevLabAppUITests" */;
+			buildPhases = (
+				6D97A8692CD24D4D00164183 /* Sources */,
+				6D97A86A2CD24D4D00164183 /* Frameworks */,
+				6D97A86B2CD24D4D00164183 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6D97A86F2CD24D4D00164183 /* PBXTargetDependency */,
+			);
+			name = RochelleDevLabAppUITests;
+			productName = RochelleDevLabAppUITests;
+			productReference = 6D97A86D2CD24D4D00164183 /* RochelleDevLabAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6D97A8452CD24D4C00164183 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1540;
+				LastUpgradeCheck = 1540;
+				TargetAttributes = {
+					6D97A84C2CD24D4C00164183 = {
+						CreatedOnToolsVersion = 15.4;
+					};
+					6D97A8622CD24D4D00164183 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = 6D97A84C2CD24D4C00164183;
+					};
+					6D97A86C2CD24D4D00164183 = {
+						CreatedOnToolsVersion = 15.4;
+						TestTargetID = 6D97A84C2CD24D4C00164183;
+					};
+				};
+			};
+			buildConfigurationList = 6D97A8482CD24D4C00164183 /* Build configuration list for PBXProject "RochelleDevLabApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 6D97A8442CD24D4C00164183;
+			productRefGroup = 6D97A84E2CD24D4C00164183 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6D97A84C2CD24D4C00164183 /* RochelleDevLabApp */,
+				6D97A8622CD24D4D00164183 /* RochelleDevLabAppTests */,
+				6D97A86C2CD24D4D00164183 /* RochelleDevLabAppUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6D97A84B2CD24D4C00164183 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6D97A85A2CD24D4D00164183 /* Assets.xcassets in Resources */,
+				6D97A85D2CD24D4D00164183 /* Base in Resources */,
+				6D97A8582CD24D4C00164183 /* Base in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D97A8612CD24D4D00164183 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D97A86B2CD24D4D00164183 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6D97A8492CD24D4C00164183 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6D97A8552CD24D4C00164183 /* ViewController.swift in Sources */,
+				6D97A8512CD24D4C00164183 /* AppDelegate.swift in Sources */,
+				6D97A8532CD24D4C00164183 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D97A85F2CD24D4D00164183 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6D97A8682CD24D4D00164183 /* RochelleDevLabAppTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6D97A8692CD24D4D00164183 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6D97A8742CD24D4D00164183 /* RochelleDevLabAppUITestsLaunchTests.swift in Sources */,
+				6D97A8722CD24D4D00164183 /* RochelleDevLabAppUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6D97A8652CD24D4D00164183 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6D97A84C2CD24D4C00164183 /* RochelleDevLabApp */;
+			targetProxy = 6D97A8642CD24D4D00164183 /* PBXContainerItemProxy */;
+		};
+		6D97A86F2CD24D4D00164183 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 6D97A84C2CD24D4C00164183 /* RochelleDevLabApp */;
+			targetProxy = 6D97A86E2CD24D4D00164183 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		6D97A8562CD24D4C00164183 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6D97A8572CD24D4C00164183 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		6D97A85B2CD24D4D00164183 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6D97A85C2CD24D4D00164183 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		6D97A8752CD24D4D00164183 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		6D97A8762CD24D4D00164183 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6D97A8782CD24D4D00164183 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R94YP9SKB4;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = RochelleDevLabApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.AkCoo.RochelleDevLabApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6D97A8792CD24D4D00164183 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R94YP9SKB4;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = RochelleDevLabApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.AkCoo.RochelleDevLabApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		6D97A87B2CD24D4D00164183 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R94YP9SKB4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.AkCoo.RochelleDevLabAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RochelleDevLabApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RochelleDevLabApp";
+			};
+			name = Debug;
+		};
+		6D97A87C2CD24D4D00164183 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R94YP9SKB4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.AkCoo.RochelleDevLabAppTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/RochelleDevLabApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/RochelleDevLabApp";
+			};
+			name = Release;
+		};
+		6D97A87E2CD24D4D00164183 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R94YP9SKB4;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.AkCoo.RochelleDevLabAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = RochelleDevLabApp;
+			};
+			name = Debug;
+		};
+		6D97A87F2CD24D4D00164183 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = R94YP9SKB4;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.AkCoo.RochelleDevLabAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = RochelleDevLabApp;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6D97A8482CD24D4C00164183 /* Build configuration list for PBXProject "RochelleDevLabApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D97A8752CD24D4D00164183 /* Debug */,
+				6D97A8762CD24D4D00164183 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6D97A8772CD24D4D00164183 /* Build configuration list for PBXNativeTarget "RochelleDevLabApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D97A8782CD24D4D00164183 /* Debug */,
+				6D97A8792CD24D4D00164183 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6D97A87A2CD24D4D00164183 /* Build configuration list for PBXNativeTarget "RochelleDevLabAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D97A87B2CD24D4D00164183 /* Debug */,
+				6D97A87C2CD24D4D00164183 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6D97A87D2CD24D4D00164183 /* Build configuration list for PBXNativeTarget "RochelleDevLabAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D97A87E2CD24D4D00164183 /* Debug */,
+				6D97A87F2CD24D4D00164183 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6D97A8452CD24D4C00164183 /* Project object */;
+}

--- a/RochelleDevLabApp/RochelleDevLabApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RochelleDevLabApp/RochelleDevLabApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/RochelleDevLabApp/RochelleDevLabApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RochelleDevLabApp/RochelleDevLabApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/RochelleDevLabApp/RochelleDevLabApp/AppDelegate.swift
+++ b/RochelleDevLabApp/RochelleDevLabApp/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  RochelleDevLabApp
+//
+//  Created by 이연정 on 10/30/24.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
+
+  // MARK: UISceneSession Lifecycle
+
+  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+  }
+
+
+}
+

--- a/RochelleDevLabApp/RochelleDevLabApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/RochelleDevLabApp/RochelleDevLabApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RochelleDevLabApp/RochelleDevLabApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/RochelleDevLabApp/RochelleDevLabApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RochelleDevLabApp/RochelleDevLabApp/Assets.xcassets/Contents.json
+++ b/RochelleDevLabApp/RochelleDevLabApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/LaunchScreen.storyboard
+++ b/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/Main.storyboard
+++ b/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/Main.storyboard
+++ b/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/Main.storyboard
@@ -62,6 +62,13 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="원" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SGJ-4x-jXB">
+                                        <rect key="frame" x="299" y="15" width="15" height="21"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                                 <color key="backgroundColor" red="0.94509803921568625" green="0.94509803921568625" blue="0.94509803921568625" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
@@ -89,6 +96,7 @@
                     <connections>
                         <outlet property="afterButtonPressed" destination="Hg6-4Z-JvC" id="pGT-66-i0G"/>
                         <outlet property="resultLabel" destination="L1i-xi-E6g" id="xVK-SP-6CC"/>
+                        <outlet property="resultLabelUnit" destination="SGJ-4x-jXB" id="GNu-92-KEh"/>
                         <outlet property="textField" destination="icC-Oa-1yB" id="fbO-8m-cDt"/>
                     </connections>
                 </viewController>

--- a/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/Main.storyboard
+++ b/RochelleDevLabApp/RochelleDevLabApp/Base.lproj/Main.storyboard
@@ -1,24 +1,105 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="RochelleDevLabApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QGc-oY-QKp">
+                                <rect key="frame" x="25" y="187" width="343" height="50"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HpK-Bg-xC4">
+                                        <rect key="frame" x="281" y="9" width="54" height="32"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="지출"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                <integer key="value" value="16"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="buttonPressed:" destination="BYZ-38-t0r" eventType="touchUpInside" id="hWD-cV-cLL"/>
+                                        </connections>
+                                    </button>
+                                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="지출을 입력하세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="icC-Oa-1yB">
+                                        <rect key="frame" x="13" y="9" width="260" height="32"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                    </textField>
+                                </subviews>
+                                <color key="backgroundColor" red="0.94509803921568625" green="0.94509803921568625" blue="0.94509803921568625" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="4S8-dh-tab"/>
+                                    <constraint firstAttribute="width" constant="343" id="QKQ-lH-H1R"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="25"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hg6-4Z-JvC">
+                                <rect key="frame" x="25" y="267" width="343" height="50"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="resultLabel" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L1i-xi-E6g">
+                                        <rect key="frame" x="129.66666666666666" y="14.666666666666686" width="84" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" red="0.94509803921568625" green="0.94509803921568625" blue="0.94509803921568625" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="343" id="8W5-Ii-LrV"/>
+                                    <constraint firstAttribute="height" constant="50" id="bcn-C8-DHo"/>
+                                    <constraint firstItem="L1i-xi-E6g" firstAttribute="centerY" secondItem="Hg6-4Z-JvC" secondAttribute="centerY" id="tcI-IS-rTS"/>
+                                    <constraint firstItem="L1i-xi-E6g" firstAttribute="centerX" secondItem="Hg6-4Z-JvC" secondAttribute="centerX" id="x18-Qb-qSv"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="25"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Hg6-4Z-JvC" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="b3K-be-6yy"/>
+                            <constraint firstItem="QGc-oY-QKp" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="m5e-GN-3Zp"/>
+                            <constraint firstItem="QGc-oY-QKp" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="128" id="m80-ig-8Vh"/>
+                            <constraint firstItem="Hg6-4Z-JvC" firstAttribute="top" secondItem="QGc-oY-QKp" secondAttribute="bottom" constant="30" id="yaT-9f-txe"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="afterButtonPressed" destination="Hg6-4Z-JvC" id="pGT-66-i0G"/>
+                        <outlet property="resultLabel" destination="L1i-xi-E6g" id="xVK-SP-6CC"/>
+                        <outlet property="textField" destination="icC-Oa-1yB" id="fbO-8m-cDt"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="119.84732824427481" y="3.5211267605633805"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/RochelleDevLabApp/RochelleDevLabApp/Info.plist
+++ b/RochelleDevLabApp/RochelleDevLabApp/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/RochelleDevLabApp/RochelleDevLabApp/SceneDelegate.swift
+++ b/RochelleDevLabApp/RochelleDevLabApp/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  RochelleDevLabApp
+//
+//  Created by 이연정 on 10/30/24.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+  var window: UIWindow?
+
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+    guard let _ = (scene as? UIWindowScene) else { return }
+  }
+
+  func sceneDidDisconnect(_ scene: UIScene) {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+  }
+
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+  }
+
+  func sceneWillResignActive(_ scene: UIScene) {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+  }
+
+  func sceneWillEnterForeground(_ scene: UIScene) {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+  }
+
+  func sceneDidEnterBackground(_ scene: UIScene) {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+  }
+
+
+}
+

--- a/RochelleDevLabApp/RochelleDevLabApp/ViewController.swift
+++ b/RochelleDevLabApp/RochelleDevLabApp/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: UIViewController {
   
   @IBOutlet weak var resultLabel: UILabel!
   
+  @IBOutlet weak var resultLabelUnit: UILabel!
   
   
   override func viewDidLoad() {

--- a/RochelleDevLabApp/RochelleDevLabApp/ViewController.swift
+++ b/RochelleDevLabApp/RochelleDevLabApp/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  RochelleDevLabApp
+//
+//  Created by 이연정 on 10/30/24.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    // Do any additional setup after loading the view.
+  }
+
+
+}
+

--- a/RochelleDevLabApp/RochelleDevLabApp/ViewController.swift
+++ b/RochelleDevLabApp/RochelleDevLabApp/ViewController.swift
@@ -8,12 +8,36 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+  
+  @IBOutlet weak var textField: UITextField!
+  
+  @IBOutlet weak var afterButtonPressed: UIView!
+  
+  @IBOutlet weak var resultLabel: UILabel!
+  
+  
+  
   override func viewDidLoad() {
     super.viewDidLoad()
-    // Do any additional setup after loading the view.
+    
+    afterButtonPressed.isHidden = true
+    
   }
-
-
+  
+  @IBAction func buttonPressed(_ sender: UIButton) {
+    
+    afterButtonPressed.isHidden = false
+    
+    
+    if textField.text?.isEmpty == false {
+      let number = Int(textField.text!) ?? 0
+      
+      let numberFormatter = NumberFormatter()
+      numberFormatter.numberStyle = .decimal
+      
+      resultLabel.text = numberFormatter.string(from: NSNumber(value: number))
+    } else {
+      resultLabel.text = "숫자를 입력하세요"
+    }
+  }
 }
-

--- a/RochelleDevLabApp/RochelleDevLabAppTests/RochelleDevLabAppTests.swift
+++ b/RochelleDevLabApp/RochelleDevLabAppTests/RochelleDevLabAppTests.swift
@@ -1,0 +1,36 @@
+//
+//  RochelleDevLabAppTests.swift
+//  RochelleDevLabAppTests
+//
+//  Created by 이연정 on 10/30/24.
+//
+
+import XCTest
+@testable import RochelleDevLabApp
+
+final class RochelleDevLabAppTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/RochelleDevLabApp/RochelleDevLabAppUITests/RochelleDevLabAppUITests.swift
+++ b/RochelleDevLabApp/RochelleDevLabAppUITests/RochelleDevLabAppUITests.swift
@@ -1,0 +1,41 @@
+//
+//  RochelleDevLabAppUITests.swift
+//  RochelleDevLabAppUITests
+//
+//  Created by 이연정 on 10/30/24.
+//
+
+import XCTest
+
+final class RochelleDevLabAppUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/RochelleDevLabApp/RochelleDevLabAppUITests/RochelleDevLabAppUITestsLaunchTests.swift
+++ b/RochelleDevLabApp/RochelleDevLabAppUITests/RochelleDevLabAppUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  RochelleDevLabAppUITestsLaunchTests.swift
+//  RochelleDevLabAppUITests
+//
+//  Created by 이연정 on 10/30/24.
+//
+
+import XCTest
+
+final class RochelleDevLabAppUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
안녕하세요 몽쉘입니다.
1일차 미션을 보고 생각한 흐름들을 적어보겠습니다.

🔸**디자인**
저희의 뷰에서 필요한 요소가 무엇인지 확인했습니다. 제 눈에는 텍스트 필드, 지출 버튼, 그 밑의 알약같은 네모와 레이블 정도가 보였어요.
그래서 사용한 라이브러리 - UI View, Button, TextField, Label

저는 저 알약 모양이 너무 하고 싶은데,,,, 검색을 해보니 코드로 구현할 수 있더라구요?
근데 스토리보드에서 다 그리고 싶어서 User Defined Runtime Attributes에서 R값을 주었습니다.(맞는지는 모르겠어요)
<img width="259" alt="스크린샷 2024-10-31 오전 4 09 21" src="https://github.com/user-attachments/assets/7c01fd13-5499-44c3-86d0-89a9fddfe372">


🔸**해당 화면 구성 시 고민한 것 및 실제 구현한 방법**
_1. 텍스트 필드에 숫자만 기입 가능 -> NumberPad 설정_
저희는 지출 금액을 입력해야 하기 때문에 아예 숫자 키패드를 올려두어 숫자만 적을 수 있게 했습니다.

_2. 지출 버튼을 눌렀을 때 밑에 알약 모양과 함께 텍스트 필드에서 적은 text가 나와야 함 -> is Hidden 처리_
버튼을 누르기 전에는 밑에 알약과 텍스트 필드에 적은 숫자가 나오지 않아야 하기 때문에 처리했습니다.

_3. 자릿수 마다 , 기입 -> NumberFormatter 인스턴스 생성_
<numberStyle>
.none: 기본 숫자 스타일 (형식화하지 않음)
.decimal: 소수점 및 천 단위 구분 쉼표가 추가된 숫자 (예: 1,000.00)
.currency: 현재 지역의 통화로 표시 (예: $1,000.00)
.percent: 퍼센트 형식 (예: 10%)
.scientific: 과학적 표기법 (예: 1.23e+5)
.ordinal: 서수로 표시 (예: 1st, 2nd)

숫자를 통화, 퍼센트, 소수점, 천 단위 구분 등 다양한 형식으로 포맷할 때 NumberFormatter를 사용한다고 검색을 통해 알았습니다.
그래서 텍스트 필드의 문자열을 숫자로 변경해서 NumberFormatter.dercimal로 천 단위 구분 쉼표가 추가될 수 있도록 변경하고
제가 레이블로 적어놨기 때문에 다시 숫자에서 문자열로 변경하였습니다.

_4. 아무것도 기입하지 않고 지출 버튼을 누른 경우 -> 비었을 때는 “숫자를 입력하세요” 나올 수 있게 처리_
저는 숫자 키패드로 박아놨기 때문에 다른 문자가 적힐 일이 없다고 생각하고 빈 배열일 때만 예외 처리 생각을 했습니다.
그래서 빈 배열일 때는 숫자를 입력하세요 라는 워딩이 나올 수 있도록 처리 해두었습니다.

🔸 **구현한 화면**
![ScreenRecording_10-31-2024 04-22-41_1](https://github.com/user-attachments/assets/1aa92b66-9cbd-4e09-8107-c00a129d18d2)




PR 어떻게 쓰는지 모르겠지만 일단 구구절절 남겨봅니다…🔥😭
